### PR TITLE
Add CI, nightly builds and pull request build links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+# Builds, tests and packages a downloadable test build. Pushes to "develop" are
+# covered by the nightly workflow instead, which additionally publishes a
+# snapshot release.
+#
+# Pull requests cover branch work, so pushes are only built for master. Listing
+# both would build every pull request branch twice, once per event.
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# A newer push to the same branch makes an in-flight run obsolete.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/job_build.yml
+    with:
+      retention_days: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 # Builds, tests and packages a downloadable test build. Pushes to "develop" are
 # covered by the nightly workflow instead, which additionally publishes a
-# snapshot release.
+# snapshot release. Links to pull request builds are posted by comment_build.yml.
 #
 # Pull requests cover branch work, so pushes are only built for master. Listing
 # both would build every pull request branch twice, once per event.

--- a/.github/workflows/comment_build.yml
+++ b/.github/workflows/comment_build.yml
@@ -85,8 +85,10 @@ jobs:
 
             // A single comment is edited in place, so that a long lived pull
             // request does not accumulate one per push.
+            // Every page is walked: missing the marker on a talkative pull
+            // request would post a fresh comment on each push instead.
             const marker = '<!-- bot: build-links -->';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: pr.number,
             });
             const existing = comments.filter(c => c.body.includes(marker)).pop();

--- a/.github/workflows/comment_build.yml
+++ b/.github/workflows/comment_build.yml
@@ -1,0 +1,107 @@
+name: Post build links to pull request
+
+# Runs separately from CI on purpose. A workflow triggered by "pull_request" gets
+# a read-only token when the pull request comes from a fork, so it cannot comment;
+# "workflow_run" executes in the context of this repository and can.
+#
+# Artifact download URLs require a logged in GitHub account, so the links point at
+# nightly.link, which proxies them for anonymous visitors.
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+
+            // The workflow_run payload does not carry the pull request number, so
+            // it has to be recovered from the commit the run was built from.
+            let pr;
+            for await (const { data } of github.paginate.iterator(github.rest.pulls.list, { owner, repo, state: 'open' }))
+            {
+                pr = data.find(p => p.head.sha === headSha);
+                if (pr) break;
+            }
+            if (!pr)
+            {
+                core.warning(`No open pull request found for ${headSha}; nothing to comment on.`);
+                return;
+            }
+
+            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner, repo, run_id: context.payload.workflow_run.id,
+            });
+
+            // Test results are for maintainers reading the run, not for testers.
+            const builds = artifacts.filter(a => a.name !== 'test-results');
+            if (!builds.length)
+            {
+                core.warning('Run produced no build artifacts; nothing to comment on.');
+                return;
+            }
+
+            // Reported by the API rather than computed, so the comment cannot
+            // disagree with the retention actually applied to the artifact.
+            const expiry = a => new Date(a.expires_at).toISOString().slice(0, 10);
+            const size = a => `${Math.round(a.size_in_bytes / 1048576)} MB`;
+
+            // Two links per build, because neither is sufficient alone: GitHub
+            // refuses artifact downloads to anonymous visitors, and nightly.link,
+            // which proxies them, is a single third party that does go down.
+            const suite = context.payload.workflow_run.check_suite_id;
+            const direct = a => `https://github.com/${owner}/${repo}/suites/${suite}/artifacts/${a.id}`;
+            const mirror = a => `https://nightly.link/${owner}/${repo}/suites/${suite}/artifacts/${a.id}`;
+
+            const links = builds
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(a => `* **${a.name}.zip** - ${size(a)}, expires ${expiry(a)}: [download](${direct(a)}) (needs a GitHub account) or [mirror](${mirror(a)}) (no account needed)`)
+                .join('\n');
+
+            // Paragraphs are single lines on purpose: GitHub renders a lone
+            // newline as a hard break, so wrapped prose comes out ragged.
+            const body = [
+                `Test build for ${headSha.slice(0, 7)}:`,
+                '',
+                links,
+                '',
+                'This is an overlay, not a full install: TombIDE project templates and native libraries for other platforms are left out to keep the download small. Install a [stable release](https://github.com/TombEngine/TombEditorReleases/releases) first, then unpack this over it, replacing existing files.',
+                '',
+                'The binaries are unsigned, so Windows SmartScreen will warn on first run.',
+            ].join('\n');
+
+            // A single comment is edited in place, so that a long lived pull
+            // request does not accumulate one per push.
+            const marker = '<!-- bot: build-links -->';
+            const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: pr.number,
+            });
+            const existing = comments.filter(c => c.body.includes(marker)).pop();
+
+            if (existing)
+            {
+                core.info(`Updating comment ${existing.id} on #${pr.number}`);
+                await github.rest.issues.updateComment({
+                    owner, repo, comment_id: existing.id, body: `${marker}\n${body}`,
+                });
+            }
+            else
+            {
+                core.info(`Creating a comment on #${pr.number}`);
+                await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number, body: `${marker}\n${body}`,
+                });
+            }

--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -1,0 +1,147 @@
+name: Build and test
+
+# Shared by ci.yml, nightly.yml and the pull request test builds. The packaged
+# tree is uploaded as an artifact rather than a zip, so that GitHub's own
+# artifact archive is the download and nothing ends up zipped twice.
+on:
+  workflow_call:
+    inputs:
+      retention_days:
+        type: number
+        description: "How long to keep the packaged build artifact"
+        required: true
+    outputs:
+      asset:
+        description: "Name of the uploaded build artifact"
+        value: ${{ jobs.build.outputs.asset }}
+      version:
+        description: "Stamped assembly version"
+        value: ${{ jobs.build.outputs.version }}
+      built:
+        description: "Build timestamp, UTC"
+        value: ${{ jobs.build.outputs.built }}
+
+jobs:
+  build:
+    # Windows is required: all but one project target net6.0-windows and use
+    # WinForms/WPF, so the solution cannot be built on Linux runners.
+    runs-on: windows-latest
+
+    outputs:
+      asset: ${{ steps.package.outputs.asset }}
+      version: ${{ steps.version.outputs.version }}
+      built: ${{ steps.version.outputs.built }}
+
+    steps:
+      # Pull requests build the head commit rather than the merge commit, so
+      # that a tester gets exactly the revision under review.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up .NET 6 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      # GenerateAssemblyInfo is off across the solution, so the version cannot be
+      # passed to MSBuild and the shared assembly info file is rewritten instead.
+      # The run number and commit hash make otherwise identical builds
+      # distinguishable in bug reports.
+      - name: Stamp build version
+        id: version
+        shell: pwsh
+        run: |
+          $file = "GlobalAssemblyInfo.cs"
+          $base = [regex]::Match((Get-Content $file -Raw), 'AssemblyVersion\("([^"]+)"\)').Groups[1].Value
+          if (-not $base) { throw "Could not read AssemblyVersion from $file" }
+          $sha = "${{ github.event.pull_request.head.sha || github.sha }}".Substring(0, 7)
+          $version = "$base.${{ github.run_number }}"
+          Set-Content -Path $file -Encoding UTF8 -Value @"
+          using System.Reflection;
+
+          [assembly: AssemblyVersion("$version")]
+          [assembly: AssemblyFileVersion("$version")]
+          [assembly: AssemblyInformationalVersion("$version+$sha")]
+          "@
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "sha=$sha" >> $env:GITHUB_OUTPUT
+          "built=$((Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm')) UTC" >> $env:GITHUB_OUTPUT
+
+      - name: Restore
+        run: dotnet restore "Tomb Editor.sln" -p:Platform=x64
+
+      - name: Build
+        run: dotnet build "Tomb Editor.sln" -c Release -p:Platform=x64 --no-restore
+
+      # A failing test fails the job, so nothing downstream packages or publishes.
+      - name: Test TombLib
+        run: >
+          dotnet test "TombLib/TombLib.Test/TombLib.Test.csproj"
+          -c Release -p:Platform=x64 --no-build
+          --logger "trx;LogFileName=TombLib.Test.trx"
+          --results-directory TestResults
+
+      - name: Test TombEditor
+        run: >
+          dotnet test "TombEditor.Tests/TombEditor.Tests.csproj"
+          -c Release -p:Platform=x64 --no-build
+          --logger "trx;LogFileName=TombEditor.Tests.trx"
+          --results-directory TestResults
+
+      # Uploaded even when a test step fails, so failures can be inspected
+      # without re-running the build locally.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults
+          retention-days: ${{ inputs.retention_days }}
+          if-no-files-found: ignore
+
+      # Builds are an overlay on an existing install rather than a full one,
+      # which keeps the download around 30 MB instead of 370 MB. Pruning is
+      # deliberately fatal if a path is missing, so that a future layout change
+      # cannot silently turn this back into a full package.
+      - name: Package
+        id: package
+        shell: pwsh
+        run: |
+          $root = "BuildRelease (x64)\net6.0-windows"
+          $templates = Join-Path $root "TIDE\Templates"
+          $runtimes = Join-Path $root "Runtimes"
+          foreach ($path in @($templates, $runtimes))
+          {
+              if (-not (Test-Path $path)) { throw "Expected to prune $path but it does not exist" }
+          }
+
+          # TombIDE project templates are already-compressed archives that change
+          # rarely and nothing else in the suite reads them.
+          Remove-Item -Recurse -Force $templates
+
+          # Native dependencies are shipped per RID; .NET only ever probes the
+          # current one, so the other platforms are dead weight in an x64 build.
+          Get-ChildItem $runtimes -Directory | Where-Object { $_.Name -ne "win-x64" } | Remove-Item -Recurse -Force
+
+          # Moved out of "BuildRelease (x64)" because the space and parentheses in
+          # that name are awkward to feed to the artifact upload's path globbing.
+          Move-Item $root package
+
+          "asset=TombEditor-${{ steps.version.outputs.version }}-${{ steps.version.outputs.sha }}" >> $env:GITHUB_OUTPUT
+
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.asset }}
+          path: package/
+          retention-days: ${{ inputs.retention_days }}
+          compression-level: 9

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,84 @@
+name: Nightly
+
+# Builds, tests and publishes a portable snapshot of the current "develop" head
+# to a single rolling pre-release tagged "nightly".
+#
+# This is a developer/tester channel and is deliberately kept separate from the
+# curated stable channel: released installers live in TombEngine/TombEditorReleases
+# and are still produced by hand, as described in Installer_compile_instructions.txt.
+# Snapshots ship as a plain zip only - the presence of an NSIS installer stays the
+# marker of a real release - and are pruned to an overlay, see job_build.yml.
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+# Only the newest commit on develop is worth publishing.
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # The release asset is the durable copy, so the artifact only has to survive
+    # long enough for the publish job to collect it.
+    uses: ./.github/workflows/job_build.yml
+    with:
+      retention_days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.asset }}
+          path: build
+
+      - name: Package
+        id: package
+        run: |
+          sha="${{ github.sha }}"
+          name="TombEditor-nightly-${sha:0:7}.zip"
+          (cd build && zip -qr "../$name" .)
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "size=$(du -m "$name" | cut -f1) MB" >> "$GITHUB_OUTPUT"
+
+      # The rolling release is recreated rather than amended, so the tag always
+      # points at the commit the assets were actually built from.
+      - name: Publish rolling pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # There is no checkout in this job, so gh cannot infer the repository
+          # from a git remote and has to be told which one to act on.
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Absent on the first ever run, so a failure to delete is not fatal.
+          gh release delete nightly --yes --cleanup-tag || true
+          cat > notes.md <<'NOTES'
+          Automated snapshot of `develop` - **not a release**.
+
+          | | |
+          |---|---|
+          | Version | `${{ needs.build.outputs.version }}` |
+          | Commit | ${{ github.sha }} |
+          | Built | ${{ needs.build.outputs.built }} |
+          | Size | ${{ steps.package.outputs.size }} |
+
+          This is an overlay, not a full install. TombIDE project templates and native libraries for other platforms are left out to keep the download small, so install a [stable release](https://github.com/TombEngine/TombEditorReleases/releases) first, then unpack this over it, replacing existing files.
+
+          TombEditor, WadTool and SoundTool run from this zip on their own; only TombIDE needs the templates, to create new projects. Requires 64-bit Windows with .NET 6 or later and a DirectX 10 capable video card.
+
+          These binaries are unsigned, so Windows SmartScreen will warn on first run. Snapshots are untested beyond the automated suite and may corrupt project files - back up your work and use a stable installer for real level building.
+          NOTES
+          gh release create nightly "${{ steps.package.outputs.name }}" \
+            --prerelease \
+            --target "${{ github.sha }}" \
+            --title "Development snapshot" \
+            --notes-file notes.md

--- a/TombLib/TombLib.Test/ViewModels/GeometryIOSettingsWindowViewModelTests.cs
+++ b/TombLib/TombLib.Test/ViewModels/GeometryIOSettingsWindowViewModelTests.cs
@@ -215,7 +215,8 @@ public class GeometryIOSettingsWindowViewModelTests
 		// Arrange
 		var animationSettings = new IOGeometryInternalSettings
 		{
-			ProcessAnimations = true
+			ProcessAnimations = true,
+			ProcessGeometry = false
 		};
 
 		var viewModel = CreateViewModel(internalSettings: animationSettings);


### PR DESCRIPTION
Right now nothing builds the solution or runs the test suite automatically. This adds GitHub Actions on Windows runners (free for public repos) to build and test everything, then reuses that build so testers have something to download.

- Pull requests: build, run tests, and post a comment with a downloadable artifact (kept for 15 days)
- Pushes to `develop`: same as above, plus update a rolling `nightly` pre-release

`job_build.yml` is shared between both workflows, so the build logic only lives in one place.

This is demonstrated on my fork:
- [nightly release](https://github.com/rr-/Tomb-Editor/releases/tag/nightly)
- [example pull request](https://github.com/rr-/Tomb-Editor/pull/1)
- [workflows](https://github.com/rr-/Tomb-Editor/tree/develop/.github/workflows)

End-to-end CI takes about 2m40s.
The snapshot ZIP is about 30 MB. The full build output is around 370 MB, mostly because of `TIDE/Templates` and native libraries for platforms an x64 build never loads. Those are stripped out, and the ZIP is meant to be extracted over an existing installation. Only TombIDE actually uses the templates. If you'd rather have the snapshots be self-contained, I can do that instead, but I'd recommend against it, as serving 400 MB for nightly builds and PR snapshots seems excessive :)

The first commit fixes a failing test. `CanInvertFaces_WhenProcessAnimationsIsTrue_ReturnsFalse` has been failing on `develop` because it leaves `ProcessGeometry` at its default (`true`), while `CanInvertFaces` is based entirely on that property. In production, `ProcessAnimations = true` is always paired with `ProcessGeometry = false`. I'm happy to split that fix into a separate PR if you'd rather keep it separate.

Releases are unchanged; installers are still built manually and published to `TombEditorReleases`. The nightly snapshots are just ZIPs with no installer, published under a single rolling pre-release and clearly marked as "not a release" – they're just a testing channel, not a second set of releases.

Two small caveats: `comment_build.yml` only runs from the default branch, so PR comments won't appear until this lands on `master`. Also, CI won't pass on `master` as it stands, since `TombLib.Rendering` requires full MSBuild rather than `dotnet build`.
