### PR TITLE
Add air bubble / blood / weather nodes

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -39,6 +39,9 @@ TEN nodes:
  * Added a node to unswap a previously swapped mesh.
  * Added nodes for checking and setting various aspects of creature AI.
  * Added a node to check Lara's traversal mode.
+ * Added node to emit weather effects from a volume.
+ * Added node to emit blood from a moveable.
+ * Added node to emit air bubble from a moveable.
  * Updated keypad nodes to use display items and allow conditional numerical input.
  * Fixed CLOCKWORK_BEETLE, EXAMINE and WATERSKIN items not appearing in the inventory nodes.
  

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
@@ -125,3 +125,79 @@ LevelFuncs.Engine.Node.Shockwave = function(pos, meshnum, innerRadius, outerRadi
 		TEN.Effects.EmitShockwave(origin, radiusInVar, radiusOutVar, color, lifetime, speed, angle, damage)
 	end
 end
+
+-- !Name "Emit air bubble from moveable"
+-- !Section "Particles"
+-- !Description "Emit an air bubble effect from a chosen moveable. Moveable must be placed underwater"
+-- !Arguments "NewLine, Moveables, 50, Moveable to emit air bubble from."
+-- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {32}, size"
+-- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {32}, oscillation amplitude"
+
+LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, size, osc)
+	
+	local moveable = TEN.Objects.GetMoveableByName(mov)
+	local moveableRoom = moveable:GetRoom()	
+	local origin = moveable:GetPosition()
+
+	if (moveableRoom:GetFlag(TEN.Objects.RoomFlagID.WATER) == false) then
+		print("Moveable must be placed underwater to emit air bubble")
+		return
+	end
+
+	TEN.Effects.EmitAirBubble(origin,size,osc)
+end
+
+-- !Name "Emit blood from moveable"
+-- !Section "Particles"
+-- !Description "Emit a blood effect from a chosen moveable."
+-- !Arguments "NewLine, Moveables, 75, Moveable to emit blood from."
+-- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {1}, sprite count"
+
+LevelFuncs.Engine.Node.EmitBloodMoveable = function(mov, spriteCount)
+	
+	local moveable = TEN.Objects.GetMoveableByName(mov)
+	local origin = moveable:GetPosition()
+
+	TEN.Effects.EmitBlood(origin,spriteCount)
+end
+
+-- !Name "Emit weather from volume"
+-- !Section "Particles"
+-- !Description "Emit a weather effect from a chosen volume."
+-- !Arguments "NewLine, Volumes, 50,  Volume to emit weather from."
+-- !Arguments "Enumeration, 50, [ Rain | Snow ], Weather type"
+-- !Arguments "NewLine, Color, 50, Color of weather effect"
+-- !Arguments "Vector3, 50, [ 0 | 64 ], {2}, initial velocity"
+-- !Arguments "NewLine, Numerical, 25, [ 0 | 20 | 1 | 1 | 5 ], {8}, random horizontal range (in blocks) around position where particles will be spawned"
+-- !Arguments "Numerical, 25, [ 0 | 20 | 1 | 1 | 5 ], {1}, random vertical range (in blocks) around position where particles will be spawned"
+-- !Arguments "Numerical, 25, [ 0 | 5 | 1 | 0.1 | 0.5 ], {1.0}, lifetime in seconds"
+-- !Arguments "Numerical, 25, [ 0 | 2 | 1 | 0.1 | 0.5 ], {1.0}, weather strength"
+-- !Arguments "NewLine, Boolean, 50, Enable clustering"
+-- !Arguments "Boolean, 50, Check wind flag"
+
+LevelFuncs.Engine.Node.EmitWeatherVolume = function(vol, weatherType, color, velocity, horizontalRange, verticalRange, life, strength, enableClustering, checkWindFlag)
+
+	if weatherType == 0 then
+		weatherType = TEN.Flow.WeatherType.RAIN
+	elseif weatherType == 1 then
+		weatherType = TEN.Flow.WeatherType.SNOW
+	end
+
+	local block = 1024
+
+	local weatherData = 
+	{
+		position = TEN.Objects.GetVolumeByName(vol):GetPosition(),
+		initialVelocity = velocity,
+		type = weatherType,
+		randomRange = horizontalRange * block,
+		randomHeight = verticalRange * block,
+		life = life,
+		strength = strength,
+		enableClustering = enableClustering,
+		checkWindFlag = checkWindFlag,
+		baseColor = color
+	}
+
+	TEN.Effects.EmitWeather(weatherData)
+end

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
@@ -140,7 +140,7 @@ LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, size, osc)
 	local origin = moveable:GetPosition()
 
 	if (moveableRoom:GetFlag(TEN.Objects.RoomFlagID.WATER) == false) then
-		print("Moveable must be placed underwater to emit air bubble")
+		print("Moveable '" .. mov .. "' must be placed underwater to emit air bubbles.")
 		return
 	end
 

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
@@ -144,7 +144,7 @@ LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, size, osc)
 		return
 	end
 
-	TEN.Effects.EmitAirBubble(origin,size,osc)
+	TEN.Effects.EmitAirBubble(origin, size, osc)
 end
 
 -- !Name "Emit blood from moveable"

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
@@ -130,14 +130,16 @@ end
 -- !Section "Particles"
 -- !Description "Emit an air bubble effect from a chosen moveable. Moveable must be placed underwater"
 -- !Arguments "NewLine, Moveables, 50, Moveable to emit air bubble from."
+-- !Arguments "Numerical, 50, [ 0 | 1024 | 0 ], {0}, joint number (optional)"
+-- !Arguments "NewLine, Vector3, 50, [ -32000 | 32000 ], { TEN.Vec3(.1,.1,.1) }, offset from joint position (in world units)"
 -- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {32}, size"
 -- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {32}, oscillation amplitude"
 
-LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, size, osc)
+LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, joint, offset, size, osc)
 	
 	local moveable = TEN.Objects.GetMoveableByName(mov)
 	local moveableRoom = moveable:GetRoom()	
-	local origin = moveable:GetPosition()
+	local origin = moveable:GetJointPosition(joint, offset) 
 
 	if (moveableRoom:GetFlag(TEN.Objects.RoomFlagID.WATER) == false) then
 		PrintLog("Moveable '" .. mov .. "' must be placed underwater to emit air bubbles.", TEN.Util.LogLevel.WARNING, false)
@@ -151,12 +153,14 @@ end
 -- !Section "Particles"
 -- !Description "Emit a blood effect from a chosen moveable."
 -- !Arguments "NewLine, Moveables, 75, Moveable to emit blood from."
--- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {1}, sprite count"
+-- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {0}, joint number (optional)"
+-- !Arguments "NewLine, Vector3, 75, [ -32000 | 32000 ], { TEN.Vec3(.1,.1,.1) }, offset from joint position (in world units)"
+-- !Arguments "Numerical, 25, [ 0 | 1024 | 0 ], {1}, sprite count per game tick"
 
-LevelFuncs.Engine.Node.EmitBloodMoveable = function(mov, spriteCount)
+LevelFuncs.Engine.Node.EmitBloodMoveable = function(mov, joint, offset, spriteCount)
 	
 	local moveable = TEN.Objects.GetMoveableByName(mov)
-	local origin = moveable:GetPosition()
+	local origin = moveable:GetJointPosition(joint, offset) 
 
 	TEN.Effects.EmitBlood(origin,spriteCount)
 end
@@ -164,18 +168,16 @@ end
 -- !Name "Emit weather from volume"
 -- !Section "Particles"
 -- !Description "Emit a weather effect from a chosen volume."
--- !Arguments "NewLine, Volumes, 50,  Volume to emit weather from."
+-- !Arguments "NewLine, Volumes, 50,  Volume to emit weather from.\nAutomatically adjusts to the width of the assigned volume."
 -- !Arguments "Enumeration, 50, [ Rain | Snow ], Weather type"
--- !Arguments "NewLine, Color, 50, Color of weather effect"
--- !Arguments "Vector3, 50, [ 0 | 64 ], {2}, initial velocity"
--- !Arguments "NewLine, Numerical, 25, [ 0 | 20 | 1 | 1 | 5 ], {8}, random horizontal range (in blocks) around position where particles will be spawned"
--- !Arguments "Numerical, 25, [ 0 | 20 | 1 | 1 | 5 ], {1}, random vertical range (in blocks) around position where particles will be spawned"
--- !Arguments "Numerical, 25, [ 0 | 5 | 1 | 0.1 | 0.5 ], {1.0}, lifetime in seconds"
+-- !Arguments "NewLine, Color, 50, { TEN.Color(255,255,255) }, Color of weather effect"
+-- !Arguments "Vector3, 50, [ 0 | 64 ], { TEN.Vec3(.1,.1,.1) }, initial velocity"
+-- !Arguments "NewLine, Numerical, 25, [ 0 | 5 | 1 | 0.1 | 0.5 ], {1.0}, lifetime in seconds"
 -- !Arguments "Numerical, 25, [ 0 | 2 | 1 | 0.1 | 0.5 ], {1.0}, weather strength"
 -- !Arguments "NewLine, Boolean, 50, Enable clustering"
 -- !Arguments "Boolean, 50, Check wind flag"
 
-LevelFuncs.Engine.Node.EmitWeatherVolume = function(vol, weatherType, color, velocity, horizontalRange, verticalRange, life, strength, enableClustering, checkWindFlag)
+LevelFuncs.Engine.Node.EmitWeatherVolume = function(vol, weatherType, color, velocity, life, strength, enableClustering, checkWindFlag)
 
 	if weatherType == 0 then
 		weatherType = TEN.Flow.WeatherType.RAIN
@@ -183,15 +185,20 @@ LevelFuncs.Engine.Node.EmitWeatherVolume = function(vol, weatherType, color, vel
 		weatherType = TEN.Flow.WeatherType.SNOW
 	end
 
-	local block = 1024
+	local volume = TEN.Objects.GetVolumeByName(vol)
+	local scale = volume:GetScale()
 
-	local weatherData = 
+	-- Use the volume's scale so the effect automatically matches its footprint.
+	local rangeXZ = math.max(scale.x, scale.z)
+	local rangeY = scale.y
+
+	local weatherData =
 	{
-		position = TEN.Objects.GetVolumeByName(vol):GetPosition(),
+		position = volume:GetPosition(),
 		initialVelocity = velocity,
 		type = weatherType,
-		randomRange = horizontalRange * block,
-		randomHeight = verticalRange * block,
+		randomRange = rangeXZ,
+		randomHeight = rangeY,
 		life = life,
 		strength = strength,
 		enableClustering = enableClustering,

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua
@@ -140,7 +140,7 @@ LevelFuncs.Engine.Node.EmitAirBubbleMoveable = function(mov, size, osc)
 	local origin = moveable:GetPosition()
 
 	if (moveableRoom:GetFlag(TEN.Objects.RoomFlagID.WATER) == false) then
-		print("Moveable '" .. mov .. "' must be placed underwater to emit air bubbles.")
+		PrintLog("Moveable '" .. mov .. "' must be placed underwater to emit air bubbles.", TEN.Util.LogLevel.WARNING, false)
 		return
 	end
 


### PR DESCRIPTION
This pull request introduces new particle effect nodes to the engine, allowing for more dynamic visual effects tied to moveables and volumes. The main changes add nodes for emitting air bubbles and blood from moveables, as well as weather effects from volumes.

### New particle effect nodes:

* Added `EmitAirBubbleMoveable` node to emit air bubble effects from a specified moveable, with checks to ensure the moveable is underwater. (`TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua`)
* Added `EmitBloodMoveable` node to emit blood effects from a specified moveable, with customizable sprite count. (`TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua`)
* Added `EmitWeatherVolume` node to emit weather effects (rain or snow) from a specified volume, with parameters for color, velocity, range, lifetime, strength, clustering, and wind flag. (`TombLib/TombLib/Catalogs/TEN Node Catalogs/Particles.lua`)

### Documentation and changelog:

* Updated `Installer/Changes.txt` to document the addition of nodes for emitting weather effects from a volume, and emitting blood and air bubbles from moveables.