### PR TITLE
Numerous fixes and adjustments to Conditional Relight

### DIFF
--- a/TombEditor.Tests/EditorLightingGatewayTests.cs
+++ b/TombEditor.Tests/EditorLightingGatewayTests.cs
@@ -1,0 +1,773 @@
+using System.Numerics;
+using TombLib;
+using TombLib.LevelData;
+
+namespace TombEditor.Tests;
+
+[TestClass]
+public class EditorLightingGatewayTests
+{
+    [TestMethod]
+    public void DeferredLightingUpdateInvalidatesWithoutRaisingEvent()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        room.RebuildLighting(highQualityLighting: false);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        editor.UpdateRoomLighting(room);
+
+        Assert.IsTrue(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+        Assert.IsFalse(editor.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public void ImmediateLightingUpdateRelightsAndRaisesNonDirtyEvent()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        room.InvalidateLighting();
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        room.InvalidateLighting();
+        editor.UpdateRoomLighting(room);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEvents.Count);
+        Assert.AreSame(room, lightingEvents[0].Room);
+        Assert.IsFalse(editor.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public void EnteringLightingModeRelightsOnlyPendingRooms()
+    {
+        using var editor = CreateEditor();
+        var cleanRoom = editor.Level.Rooms[0];
+
+        var pendingRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = pendingRoom;
+
+        cleanRoom.RebuildLighting(highQualityLighting: false);
+        pendingRoom.InvalidateLighting();
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        editor.Mode = EditorMode.Lighting;
+
+        Assert.IsFalse(cleanRoom.PendingRelight);
+        Assert.IsFalse(pendingRoom.PendingRelight);
+        Assert.AreEqual(1, lightingEvents.Count);
+        Assert.AreSame(pendingRoom, lightingEvents[0].Room);
+    }
+
+    [TestMethod]
+    public void SameRoomLightTransformUndoRelightsOneRoom()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+
+        editor.Mode = EditorMode.Lighting;
+        editor.UpdateRoomLighting(room);
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        var undo = new TransformObjectUndoInstance(editor.UndoManager, light);
+
+        light.Position += new Vector3(1024.0f, 0.0f, 0.0f);
+        editor.UpdateRoomLighting(room);
+        lightingEvents.Clear();
+
+        undo.UndoAction();
+
+        Assert.AreEqual(Vector3.Zero, light.Position);
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEvents.Count);
+        Assert.AreSame(room, lightingEvents[0].Room);
+    }
+
+    [TestMethod]
+    public void BulkLightingUpdateDeduplicatesRooms()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        editor.Mode = EditorMode.Lighting;
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        room.InvalidateLighting();
+        editor.UpdateRoomsLighting([room, room]);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void SingleLightColorChangeDefersOutsideLightingMode()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+        room.RebuildLighting(highQualityLighting: false);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        EditorActions.ApplyObjectColor(light, new Vector3(1.0f, 0.5f, 0.25f));
+
+        Assert.IsTrue(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void LightGroupColorChangeRelightsEachAffectedRoomOnce()
+    {
+        using var editor = CreateEditor();
+        var sourceRoom = editor.Level.Rooms[0];
+
+        var destinationRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = destinationRoom;
+
+        var sourceLight = new LightInstance(LightType.Point);
+        var destinationLight = new LightInstance(LightType.Point);
+
+        sourceRoom.AddObject(editor.Level, sourceLight);
+        destinationRoom.AddObject(editor.Level, destinationLight);
+
+        sourceRoom.RebuildLighting(highQualityLighting: false);
+        destinationRoom.RebuildLighting(highQualityLighting: false);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        var group = new ObjectGroup(sourceLight)
+        {
+            destinationLight
+        };
+
+        var color = new Vector3(1.0f, 0.5f, 0.25f);
+        EditorActions.ApplyObjectColor(group, color);
+
+        Assert.AreEqual(color, sourceLight.Color);
+        Assert.AreEqual(color, destinationLight.Color);
+
+        Assert.AreEqual(1, lightingEvents.Count(eventObject => eventObject.Room == sourceRoom));
+        Assert.AreEqual(1, lightingEvents.Count(eventObject => eventObject.Room == destinationRoom));
+    }
+
+    [TestMethod]
+    public void LightGroupTransformUndoRelightsRoomOnce()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        var firstLight = new LightInstance(LightType.Point);
+        var secondLight = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, firstLight);
+        room.AddObject(editor.Level, secondLight);
+        room.RebuildLighting(highQualityLighting: false);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var group = new ObjectGroup(firstLight)
+        {
+            secondLight
+        };
+
+        editor.UndoManager.PushObjectTransformed(group);
+        group.Position += new Vector3(1024.0f, 0.0f, 0.0f);
+        editor.UpdateRoomLighting(room);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        editor.UndoManager.Undo();
+
+        Assert.AreEqual(Vector3.Zero, firstLight.Position);
+        Assert.AreEqual(Vector3.Zero, secondLight.Position);
+        Assert.AreEqual(1, lightingEventCount);
+
+        lightingEventCount = 0;
+        editor.UndoManager.Redo();
+
+        Assert.AreEqual(new Vector3(1024.0f, 0.0f, 0.0f), firstLight.Position);
+        Assert.AreEqual(new Vector3(1024.0f, 0.0f, 0.0f), secondLight.Position);
+        Assert.AreEqual(1, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void LightGroupPropertyUndoRelightsRoomOnce()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        var firstLight = new LightInstance(LightType.Point)
+        {
+            Color = new Vector3(0.25f, 0.5f, 0.75f)
+        };
+
+        var secondLight = new LightInstance(LightType.Point)
+        {
+            Color = new Vector3(0.75f, 0.5f, 0.25f)
+        };
+
+        room.AddObject(editor.Level, firstLight);
+        room.AddObject(editor.Level, secondLight);
+        room.RebuildLighting(highQualityLighting: false);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var group = new ObjectGroup(firstLight)
+        {
+            secondLight
+        };
+
+        editor.UndoManager.PushObjectPropertyChanged(group);
+        group.Color = new Vector3(1.0f, 1.0f, 1.0f);
+        editor.UpdateRoomLighting(room);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        editor.UndoManager.Undo();
+
+        Assert.AreEqual(new Vector3(0.25f, 0.5f, 0.75f), firstLight.Color);
+        Assert.AreEqual(new Vector3(0.75f, 0.5f, 0.25f), secondLight.Color);
+        Assert.AreEqual(1, lightingEventCount);
+
+        lightingEventCount = 0;
+        editor.UndoManager.Redo();
+
+        Assert.AreEqual(Vector3.One, firstLight.Color);
+        Assert.AreEqual(Vector3.One, secondLight.Color);
+        Assert.AreEqual(1, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void LightingUpdateRejectsNullRoom()
+    {
+        using var editor = CreateEditor();
+        Assert.ThrowsException<ArgumentNullException>(() => editor.UpdateRoomLighting(null));
+    }
+
+    [TestMethod]
+    public void CrossRoomLightTransformUndoRelightsBothRooms()
+    {
+        using var editor = CreateEditor();
+        var sourceRoom = editor.Level.Rooms[0];
+
+        var destinationRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = destinationRoom;
+
+        var light = new LightInstance(LightType.Point);
+        editor.Mode = EditorMode.Lighting;
+
+        sourceRoom.AddObject(editor.Level, light);
+        editor.UpdateRoomLighting(sourceRoom);
+
+        var undo = new TransformObjectUndoInstance(editor.UndoManager, light);
+
+        destinationRoom.MoveObjectFrom(editor.Level, sourceRoom, light);
+        editor.UpdateRoomsLighting([sourceRoom, destinationRoom]);
+
+        undo.UndoAction();
+
+        Assert.AreSame(sourceRoom, light.Room);
+        Assert.IsFalse(sourceRoom.PendingRelight);
+        Assert.IsFalse(destinationRoom.PendingRelight);
+    }
+
+    [TestMethod]
+    public void NormalLightMovesRelightBothRoomsAndMixedRoomGroupsOnce()
+    {
+        using var editor = CreateEditor();
+        var sourceRoom = editor.Level.Rooms[0];
+
+        var destinationRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = destinationRoom;
+
+        var firstLight = new LightInstance(LightType.Point);
+        var secondLight = new LightInstance(LightType.Point);
+
+        sourceRoom.AddObject(editor.Level, firstLight);
+        destinationRoom.AddObject(editor.Level, secondLight);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        EditorActions.MoveObject(firstLight, destinationRoom, new VectorInt2(1, 1));
+
+        Assert.AreSame(destinationRoom, firstLight.Room);
+        Assert.IsFalse(sourceRoom.PendingRelight);
+        Assert.IsFalse(destinationRoom.PendingRelight);
+
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == sourceRoom));
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == destinationRoom));
+
+        lightingEvents.Clear();
+        editor.UpdateRoomLighting(destinationRoom);
+        lightingEvents.Clear();
+
+        EditorActions.MoveObjectToOtherRoom(secondLight, sourceRoom);
+
+        Assert.AreSame(sourceRoom, secondLight.Room);
+        Assert.IsFalse(sourceRoom.PendingRelight);
+        Assert.IsFalse(destinationRoom.PendingRelight);
+
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == sourceRoom));
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == destinationRoom));
+
+        lightingEvents.Clear();
+
+        var mixedRoomGroup = new ObjectGroup(firstLight)
+        {
+            secondLight
+        };
+
+        EditorActions.RebuildLightsForObject(mixedRoomGroup);
+
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == sourceRoom));
+        Assert.AreEqual(1, lightingEvents.Count(lightingEvent => lightingEvent.Room == destinationRoom));
+    }
+
+    [TestMethod]
+    public void NormalNonLightMoveDoesNotRelightRooms()
+    {
+        using var editor = CreateEditor();
+        var sourceRoom = editor.Level.Rooms[0];
+
+        var destinationRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = destinationRoom;
+
+        var camera = new CameraInstance();
+        sourceRoom.AddObject(editor.Level, camera);
+        sourceRoom.RebuildLighting(highQualityLighting: false);
+        destinationRoom.RebuildLighting(highQualityLighting: false);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        EditorActions.MoveObject(camera, destinationRoom, new VectorInt2(1, 1));
+
+        Assert.AreSame(destinationRoom, camera.Room);
+        Assert.IsFalse(sourceRoom.PendingRelight);
+        Assert.IsFalse(destinationRoom.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void PreviewQualityChangeDefersOutsideLightingAndRelightsInLightingMode()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        room.RebuildLighting(highQualityLighting: false);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        editor.Configuration.Rendering3D_HighQualityLightPreview = true;
+        editor.ConfigurationChange();
+
+        Assert.IsTrue(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+
+        editor.Mode = EditorMode.Lighting;
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+
+        editor.Configuration.Rendering3D_HighQualityLightPreview = false;
+        editor.ConfigurationChange();
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(2, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void LevelLightQualityChangeWaitsForHighQualityPreviewAndRelightsWhenActive()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        room.RebuildLighting(highQualityLighting: false);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        var settings = editor.Level.Settings.Clone();
+        settings.DefaultLightQuality = LightQuality.High;
+        editor.UpdateLevelSettings(settings);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+
+        editor.Configuration.Rendering3D_HighQualityLightPreview = true;
+        editor.ConfigurationChange();
+
+        Assert.IsTrue(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+
+        editor.Mode = EditorMode.Lighting;
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+
+        settings = editor.Level.Settings.Clone();
+        settings.OverrideIndividualLightQualitySettings = true;
+        editor.UpdateLevelSettings(settings);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(2, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void DeletingLightRaisesLightingEventWithoutGeometryEvent()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEventCount = 0;
+        var geometryEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+            else if (eventObject is Editor.RoomGeometryChangedEvent)
+                geometryEventCount++;
+        };
+
+        EditorActions.DeleteObjectWithoutUpdate(light);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+        Assert.AreEqual(0, geometryEventCount);
+    }
+
+    [TestMethod]
+    public void UndoDeletedLightRelightsRoomOnce()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+        editor.Mode = EditorMode.Lighting;
+
+        var undo = new AddRemoveObjectUndoInstance(editor.UndoManager, light, created: false);
+        EditorActions.DeleteObjectWithoutUpdate(light);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        undo.UndoAction();
+
+        Assert.AreSame(room, light.Room);
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void DynamicOnlyLightChangeRaisesObjectChangeWithoutRelighting()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+        room.RebuildLighting(highQualityLighting: false);
+
+        editor.SelectedObject = light;
+        editor.HasUnsavedChanges = false;
+
+        var objectChangeCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.ObjectChangedEvent)
+                objectChangeCount++;
+        };
+
+        EditorActions.UpdateLight<bool>((currentLight, value) => currentLight.IsDynamicallyUsed == value,
+            (currentLight, value) => currentLight.IsDynamicallyUsed = value, _ => false, updateLighting: false);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, objectChangeCount);
+        Assert.IsTrue(editor.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public void StaticLightChangeStillRelights()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(editor.Level, light);
+        room.RebuildLighting(highQualityLighting: false);
+
+        editor.SelectedObject = light;
+
+        EditorActions.UpdateLight<bool>((currentLight, value) => currentLight.IsStaticallyUsed == value,
+            (currentLight, value) => currentLight.IsStaticallyUsed = value, _ => false);
+
+        Assert.IsTrue(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void ResetLightRotationRelightsAffectedRoom()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        var light = new LightInstance(LightType.Point)
+        {
+            RotationX = 30.0f,
+            RotationY = 45.0f
+        };
+
+        room.AddObject(editor.Level, light);
+
+        editor.Mode = EditorMode.Lighting;
+        editor.UpdateRoomLighting(room);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        EditorActions.ResetObjectRotation(light);
+
+        Assert.AreEqual(0.0f, light.RotationX);
+        Assert.AreEqual(0.0f, light.RotationY);
+
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(1, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void ResetLightRotationDefersOutsideLightingMode()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        var light = new LightInstance(LightType.Point)
+        {
+            RotationY = 45.0f
+        };
+
+        room.AddObject(editor.Level, light);
+        room.RebuildLighting(highQualityLighting: false);
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        EditorActions.ResetObjectRotation(light);
+
+        Assert.AreEqual(0.0f, light.RotationY);
+        Assert.IsTrue(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void ResetNonLightRotationDoesNotRelightRoom()
+    {
+        using var editor = CreateEditor();
+        var room = editor.Level.Rooms[0];
+
+        var staticInstance = new StaticInstance
+        {
+            RotationY = 45.0f
+        };
+
+        room.AddObject(editor.Level, staticInstance);
+        room.RebuildLighting(highQualityLighting: false);
+
+        editor.Mode = EditorMode.Lighting;
+
+        var lightingEventCount = 0;
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent)
+                lightingEventCount++;
+        };
+
+        EditorActions.ResetObjectRotation(staticInstance);
+
+        Assert.AreEqual(0.0f, staticInstance.RotationY);
+        Assert.IsFalse(room.PendingRelight);
+        Assert.AreEqual(0, lightingEventCount);
+    }
+
+    [TestMethod]
+    public void ResetLightGroupRotationRelightsEachAffectedRoomOnce()
+    {
+        using var editor = CreateEditor();
+        var sourceRoom = editor.Level.Rooms[0];
+
+        var destinationRoom = new Room(editor.Level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        editor.Level.Rooms[1] = destinationRoom;
+
+        var sourceLight = new LightInstance(LightType.Point)
+        {
+            RotationY = 30.0f
+        };
+
+        var destinationLight = new LightInstance(LightType.Point)
+        {
+            RotationY = 60.0f
+        };
+
+        sourceRoom.AddObject(editor.Level, sourceLight);
+        destinationRoom.AddObject(editor.Level, destinationLight);
+
+        editor.Mode = EditorMode.Lighting;
+        editor.UpdateRoomsLighting([sourceRoom, destinationRoom]);
+
+        var lightingEvents = new List<Editor.RoomLightingChangedEvent>();
+
+        editor.EditorEventRaised += eventObject =>
+        {
+            if (eventObject is Editor.RoomLightingChangedEvent lightingEvent)
+                lightingEvents.Add(lightingEvent);
+        };
+
+        var group = new ObjectGroup(sourceLight)
+        {
+            destinationLight
+        };
+
+        group.RotationY = 45.0f;
+
+        EditorActions.ResetObjectRotation(group);
+
+        Assert.AreEqual(0.0f, group.RotationY);
+        Assert.AreEqual(30.0f, sourceLight.RotationY);
+        Assert.AreEqual(60.0f, destinationLight.RotationY);
+
+        Assert.IsFalse(sourceRoom.PendingRelight);
+        Assert.IsFalse(destinationRoom.PendingRelight);
+
+        Assert.AreEqual(1, lightingEvents.Count(eventObject => eventObject.Room == sourceRoom));
+        Assert.AreEqual(1, lightingEvents.Count(eventObject => eventObject.Room == destinationRoom));
+    }
+
+    private static Editor CreateEditor()
+    {
+        return new Editor(new ImmediateSynchronizationContext(), new Configuration(), Level.CreateSimpleLevel());
+    }
+
+    private sealed class ImmediateSynchronizationContext : SynchronizationContext
+    {
+        public override void Send(SendOrPostCallback callback, object? state)
+        {
+            callback(state);
+        }
+    }
+}

--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -1087,7 +1087,7 @@ namespace TombEditor
                     c =>
                     {
                         room.Properties.AmbientLight = c.ToFloat3Color() * 2.0f;
-                        args.Editor.SelectedRoom.RebuildLighting(args.Editor.Configuration.Rendering3D_HighQualityLightPreview);
+                        args.Editor.UpdateRoomLighting(room);
                         args.Editor.RoomPropertiesChange(room);
                     }, args.Editor.Configuration.UI_ColorScheme))
                 {
@@ -1110,7 +1110,7 @@ namespace TombEditor
                 }
 
                 args.Editor.UndoManager.Push(undo);
-                args.Editor.SelectedRoom.RebuildLighting(args.Editor.Configuration.Rendering3D_HighQualityLightPreview);
+                args.Editor.UpdateRoomLighting(room);
                 args.Editor.RoomPropertiesChange(room);
             });
 

--- a/TombEditor/Controls/PanelPalette.cs
+++ b/TombEditor/Controls/PanelPalette.cs
@@ -121,12 +121,7 @@ namespace TombEditor.Controls
                     _editor.ToggleHiddenSelection(true);
 
                     var instance = _editor.SelectedObject as IColorable;
-                    instance.Color = SelectedColor.ToFloat3Color() * 2.0f;
-
-                    if (_editor.SelectedObject is LightInstance)
-                        _editor.SelectedObject.Room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
-
-                    _editor.ObjectChange(_editor.SelectedObject, ObjectChangeType.Change);
+                    EditorActions.ApplyObjectColor(instance, SelectedColor.ToFloat3Color() * 2.0f);
                 }
 
                 _editor.LastUsedPaletteColourChange(SelectedColor);

--- a/TombEditor/Editor.cs
+++ b/TombEditor/Editor.cs
@@ -441,6 +441,7 @@ namespace TombEditor
             public bool Save { get; internal set; } = false;
         }
         private Configuration _configuration;
+        private bool _lastHighQualityLightPreview;
         public Configuration Configuration
         {
             get { return _configuration; }
@@ -448,9 +449,10 @@ namespace TombEditor
             {
                 if (value == _configuration)
                     return;
-                var previous = _configuration;
+
                 _configuration = value;
                 RaiseEvent(new ConfigurationChangedEvent { UpdateLayout = true, UpdateKeyboardShortcuts = true, Save = true });
+                UpdateLightingForPreviewQualityChange();
             }
         }
 
@@ -620,6 +622,37 @@ namespace TombEditor
         public void RoomLightingChange(Room room)
         {
             RaiseEvent(new RoomLightingChangedEvent { Room = room });
+        }
+
+        public void UpdateRoomLighting(Room room)
+        {
+            ArgumentNullException.ThrowIfNull(room);
+            SynchronizationContext.Send(_ => UpdateRoomLightingCore(room), null);
+        }
+
+        public void UpdateRoomsLighting(IEnumerable<Room> rooms)
+        {
+            ArgumentNullException.ThrowIfNull(rooms);
+
+            var distinctRooms = rooms.Where(room => room is not null).Distinct().ToList();
+
+            SynchronizationContext.Send(_ =>
+            {
+                foreach (var room in distinctRooms)
+                    UpdateRoomLightingCore(room);
+            }, null);
+        }
+
+        private void UpdateRoomLightingCore(Room room)
+        {
+            if (!ShouldRelight)
+            {
+                room.InvalidateLighting();
+                return;
+            }
+
+            room.RebuildLighting(Configuration.Rendering3D_HighQualityLightPreview);
+            RoomLightingChange(room);
         }
 
         // This is invoked when room pos is changed.
@@ -909,6 +942,21 @@ namespace TombEditor
                 Save = save,
                 UpdateToolbarLayout = updateToolbarLayout
             });
+
+            UpdateLightingForPreviewQualityChange();
+        }
+
+        private void UpdateLightingForPreviewQualityChange()
+        {
+            bool highQualityLightPreview = Configuration.Rendering3D_HighQualityLightPreview;
+
+            if (highQualityLightPreview == _lastHighQualityLightPreview)
+                return;
+
+            _lastHighQualityLightPreview = highQualityLightPreview;
+
+            if (_level is not null)
+                UpdateRoomsLighting(_level.ExistingRooms);
         }
 
         // Select a room and (optonally) center the camera
@@ -1010,6 +1058,8 @@ namespace TombEditor
             bool gameVersionChanged = newSettings.GameVersion != _level.Settings.GameVersion ||
                                       newSettings.GameEnableExtraBlendingModes != _level.Settings.GameEnableExtraBlendingModes ||
                                       newSettings.GameEnableExtraReverbPresets != _level.Settings.GameEnableExtraReverbPresets;
+            bool lightQualityChanged = newSettings.DefaultLightQuality != _level.Settings.DefaultLightQuality ||
+                                       newSettings.OverrideIndividualLightQualitySettings != _level.Settings.OverrideIndividualLightQualitySettings;
 
             // Update the current settings
             _level.ApplyNewLevelSettings(newSettings, instance => ObjectChange(instance, ObjectChangeType.Change));
@@ -1038,6 +1088,9 @@ namespace TombEditor
 
             if (gameVersionChanged)
                 GameVersionChange();
+
+            if (lightQualityChanged && Configuration.Rendering3D_HighQualityLightPreview)
+                UpdateRoomsLighting(_level.ExistingRooms);
 
             // Update file watchers
             if (importedGeometryChanged || texturesChanged || wadsChanged || soundsChanged)

--- a/TombEditor/Editor.cs
+++ b/TombEditor/Editor.cs
@@ -638,8 +638,19 @@ namespace TombEditor
 
             SynchronizationContext.Send(_ =>
             {
+                if (!ShouldRelight)
+                {
+                    foreach (var room in distinctRooms)
+                        room.InvalidateLighting();
+
+                    return;
+                }
+
+                Parallel.ForEach(distinctRooms,
+                    room => room.RebuildLighting(Configuration.Rendering3D_HighQualityLightPreview));
+
                 foreach (var room in distinctRooms)
-                    UpdateRoomLightingCore(room);
+                    RoomLightingChange(room);
             }, null);
         }
 

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -397,12 +397,30 @@ namespace TombEditor
         public static void ApplyObjectColor(IColorable obj, Vector3 color)
         {
             obj.Color = color;
+            NotifyObjectColorChanged(obj);
+        }
 
+        private static void NotifyObjectColorChanged(IColorable obj)
+        {
             if (obj is ObjectInstance instance)
             {
                 RebuildLightsForObject(instance);
                 _editor.ObjectChange(instance, ObjectChangeType.Change);
             }
+        }
+
+        private static List<(IColorable Colorable, Vector3 Color)> CaptureObjectColors(IColorable obj)
+        {
+            if (obj is ObjectGroup group)
+                return [.. group.OfType<IColorable>().Select(colorable => (colorable, colorable.Color))];
+
+            return [(obj, obj.Color)];
+        }
+
+        private static void RestoreObjectColors(IEnumerable<(IColorable Colorable, Vector3 Color)> colors)
+        {
+            foreach (var originalColor in colors)
+                originalColor.Colorable.Color = originalColor.Color;
         }
 
         public static void EditColor(IWin32Window owner, IColorable obj, Action<Vector3> newColorCallback = null)
@@ -415,23 +433,29 @@ namespace TombEditor
             {
                 colorDialog.Color = (obj.Color * 0.5f).ToWinFormsColor();
                 var oldLightColor = colorDialog.Color;
+                var originalColors = CaptureObjectColors(obj);
 
                 // Temporarily hide selection
                 _editor.ToggleHiddenSelection(true);
 
                 // Rollback to previous color if dialog is canceled or push undo if confirmed
                 if (colorDialog.ShowDialog(owner) != DialogResult.OK)
+                {
                     colorDialog.Color = oldLightColor;
+                    RestoreObjectColors(originalColors);
+                    NotifyObjectColorChanged(obj);
+                }
                 else if (obj is PositionBasedObjectInstance)
                 {
-                    obj.Color = oldLightColor.ToFloat3Color() * 2.0f;
+                    RestoreObjectColors(originalColors);
                     _editor.UndoManager.PushObjectPropertyChanged(obj as PositionBasedObjectInstance);
+                    ApplyObjectColor(obj, colorDialog.Color.ToFloat3Color() * 2.0f);
                 }
+                else
+                    ApplyObjectColor(obj, colorDialog.Color.ToFloat3Color() * 2.0f);
 
                 // Unhide selection
                 _editor.ToggleHiddenSelection(false);
-
-                ApplyObjectColor(obj, colorDialog.Color.ToFloat3Color() * 2.0f);
 
                 _editor.Configuration.ColorDialog_Position = colorDialog.Position;
                 newColorCallback?.Invoke(colorDialog.Color.ToFloat3Color());

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -39,7 +39,7 @@ namespace TombEditor
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        private static readonly Editor _editor = Editor.Instance;
+        private static Editor _editor => Editor.Instance;
 
         public static bool ContinueOnFileDrop(IWin32Window owner, string description)
         {
@@ -373,6 +373,7 @@ namespace TombEditor
                     (obj as IRotateableYXRoll).Roll = 0;
             }
 
+            RebuildLightsForObject(obj);
             _editor.ObjectChange(obj, ObjectChangeType.Change);
         }
 
@@ -393,16 +394,24 @@ namespace TombEditor
             _editor.ObjectChange(obj, ObjectChangeType.Change);
         }
 
+        public static void ApplyObjectColor(IColorable obj, Vector3 color)
+        {
+            obj.Color = color;
+
+            if (obj is ObjectInstance instance)
+            {
+                RebuildLightsForObject(instance);
+                _editor.ObjectChange(instance, ObjectChangeType.Change);
+            }
+        }
+
         public static void EditColor(IWin32Window owner, IColorable obj, Action<Vector3> newColorCallback = null)
         {
             using (var colorDialog = new RealtimeColorDialog(
                 _editor.Configuration.ColorDialog_Position.X,
                 _editor.Configuration.ColorDialog_Position.Y,
-                c =>
-                {
-                    obj.Color = c.ToFloat3Color() * 2.0f;
-                    _editor.ObjectChange(obj as ObjectInstance, ObjectChangeType.Change);
-                }, _editor.Configuration.UI_ColorScheme))
+                c => ApplyObjectColor(obj, c.ToFloat3Color() * 2.0f),
+                _editor.Configuration.UI_ColorScheme))
             {
                 colorDialog.Color = (obj.Color * 0.5f).ToWinFormsColor();
                 var oldLightColor = colorDialog.Color;
@@ -422,8 +431,7 @@ namespace TombEditor
                 // Unhide selection
                 _editor.ToggleHiddenSelection(false);
 
-                obj.Color = colorDialog.Color.ToFloat3Color() * 2.0f;
-                _editor.ObjectChange(obj as ObjectInstance, ObjectChangeType.Change);
+                ApplyObjectColor(obj, colorDialog.Color.ToFloat3Color() * 2.0f);
 
                 _editor.Configuration.ColorDialog_Position = colorDialog.Position;
                 newColorCallback?.Invoke(colorDialog.Color.ToFloat3Color());
@@ -901,11 +909,14 @@ namespace TombEditor
 
         public static void MoveObject(PositionBasedObjectInstance instance, Room targetRoom, VectorInt2 sector)
         {
-            var r = instance.Room;
+            var sourceRoom = instance.Room;
             _editor.UndoManager.PushObjectTransformed(instance);
-            instance.Room.RemoveObject(_editor.Level, instance);
-            _editor.ObjectChange(instance, ObjectChangeType.Remove, r);
-            PlaceObjectWithoutUpdate(targetRoom, sector, instance);
+            sourceRoom.RemoveObject(_editor.Level, instance);
+            _editor.ObjectChange(instance, ObjectChangeType.Remove, sourceRoom);
+            PlaceObjectWithoutUpdate(targetRoom, sector, instance, updateLighting: false);
+
+            if (instance is LightInstance)
+                _editor.UpdateRoomsLighting([sourceRoom, targetRoom]);
         }
 
         public static void MoveObject(PositionBasedObjectInstance instance, Vector3 pos, Keys modifierKeys)
@@ -973,10 +984,13 @@ namespace TombEditor
             }
 
             _editor.UndoManager.PushObjectTransformed(instance);
+            var sourceRoom = instance.Room;
             newRoom.MoveObjectFrom(_editor.Level, instance.Room, instance);
 
             // Update state
-            RebuildLightsForObject(instance);
+            if (instance is LightInstance)
+                _editor.UpdateRoomsLighting([sourceRoom, newRoom]);
+
             _editor.ObjectChange(instance, ObjectChangeType.Change);
         }
 
@@ -1026,10 +1040,14 @@ namespace TombEditor
         }
 
         public static void RebuildLightsForObject(ObjectInstance instance)
+            => _editor.UpdateRoomsLighting(GetLightingRoomsForObject(instance));
+
+        public static IEnumerable<Room> GetLightingRoomsForObject(ObjectInstance instance)
         {
-            if (instance is LightInstance ||
-               (instance is ObjectGroup && ((ObjectGroup)instance).Any(o => o is LightInstance)))
-                instance.Room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+            return (instance is ObjectGroup group
+                ? group.OfType<LightInstance>().Select(light => light.Room)
+                : instance is LightInstance ? [instance.Room] : [])
+                .Distinct();
         }
 
         public static DarkForm GetObjectSetupWindow(params object[] args)
@@ -1357,14 +1375,7 @@ namespace TombEditor
                 _editor.RoomSectorPropertiesChange(room);
 
             if (instance is LightInstance)
-            {
-                if (_editor.ShouldRelight)
-                    room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
-                else
-                    room.PendingRelight = true;
-
-                _editor.RoomGeometryChange(room);
-            }
+                _editor.UpdateRoomLighting(room);
 
             if (instance is PortalInstance)
             {
@@ -2466,15 +2477,17 @@ namespace TombEditor
             }
         }
 
-        public static void PlaceObjectWithoutUpdate(Room room, VectorInt2 pos, PositionBasedObjectInstance instance) =>
-            PlaceObjectWithoutUpdate(room, new Vector2(pos.X, pos.Y), instance);
+        public static void PlaceObjectWithoutUpdate(Room room, VectorInt2 pos, PositionBasedObjectInstance instance, bool updateLighting = true) =>
+            PlaceObjectWithoutUpdate(room, new Vector2(pos.X, pos.Y), instance, updateLighting);
 
-        public static void PlaceObjectWithoutUpdate(Room room, Vector2 pos, PositionBasedObjectInstance instance)
+        public static void PlaceObjectWithoutUpdate(Room room, Vector2 pos, PositionBasedObjectInstance instance, bool updateLighting = true)
         {
             instance.Position = room.GetFloorMidpointPosition(pos.X, pos.Y);
             room.AddObject(_editor.Level, instance);
 
-            RebuildLightsForObject(instance);
+            if (updateLighting)
+                RebuildLightsForObject(instance);
+
             AllocateScriptIds(instance);
 
             _editor.ObjectChange(instance, ObjectChangeType.Add);
@@ -4170,7 +4183,7 @@ namespace TombEditor
             return true;
         }
 
-        public static void UpdateLight<T>(Func<LightInstance, T, bool> compareEquals, Action<LightInstance, T> setLightValue, Func<LightInstance, T?> getGuiValue) where T : struct
+        public static void UpdateLight<T>(Func<LightInstance, T, bool> compareEquals, Action<LightInstance, T> setLightValue, Func<LightInstance, T?> getGuiValue, bool updateLighting = true) where T : struct
         {
             var light = _editor.SelectedObject as LightInstance;
             if (light == null)
@@ -4181,7 +4194,8 @@ namespace TombEditor
                 return;
 
             setLightValue(light, newValue.Value);
-            light.Room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+            if (updateLighting)
+                _editor.UpdateRoomLighting(light.Room);
             _editor.ObjectChange(light, ObjectChangeType.Change);
         }
 
@@ -4191,7 +4205,7 @@ namespace TombEditor
             if (light == null)
                 return;
             light.Quality = newQuality;
-            light.Room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+            _editor.UpdateRoomLighting(light.Room);
             _editor.ObjectChange(light, ObjectChangeType.Change);
         }
 
@@ -4201,7 +4215,7 @@ namespace TombEditor
             if (light == null)
                 return;
             light.Type = type;
-            light.Room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+            _editor.UpdateRoomLighting(light.Room);
             _editor.ObjectChange(light, ObjectChangeType.Change);
         }
 

--- a/TombEditor/Forms/FormReplaceObject.cs
+++ b/TombEditor/Forms/FormReplaceObject.cs
@@ -325,7 +325,7 @@ namespace TombEditor.Forms
                 if (anyObjectsChanged)
                 {
                     roomCount++;
-                    if (Source is LightInstance) room.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+                    if (Source is LightInstance) _editor.UpdateRoomLighting(room);
                 }
             }
 

--- a/TombEditor/Forms/FormRoomProperties.cs
+++ b/TombEditor/Forms/FormRoomProperties.cs
@@ -88,7 +88,7 @@ namespace TombEditor.Forms
 
                             // HACK: We need to rebuild lighting for rooms with changed AmbientLight property.
                             if (prop.Name == nameof(r.Properties.AmbientLight))
-                                r.RebuildLighting(_editor.Configuration.Rendering3D_HighQualityLightPreview);
+                                _editor.UpdateRoomLighting(r);
                         }
                     }
                 }

--- a/TombEditor/Forms/FormTransform.cs
+++ b/TombEditor/Forms/FormTransform.cs
@@ -20,6 +20,7 @@ namespace TombEditor.Forms
         private bool _loading = false;
         private bool _undoSaved = false;
         private bool _lightingUpdatePending = false;
+        private bool _dataRestored = false;
 
         public FormTransform(PositionBasedObjectInstance instance)
         {
@@ -50,7 +51,7 @@ namespace TombEditor.Forms
 
         private void RestoreData()
         {
-            if (_instance == null)
+            if (_instance == null || _dataRestored)
                 return;
 
             bool changed = HasTransformChangedFromBackup();
@@ -68,6 +69,9 @@ namespace TombEditor.Forms
 
             if (changed && _editor.ShouldRelight)
                 EditorActions.RebuildLightsForObject(_instance);
+
+            _lightingUpdatePending = false;
+            _dataRestored = true;
         }
 
         private bool HasPendingChanges()
@@ -207,6 +211,17 @@ namespace TombEditor.Forms
             nudScaleZ.Value = nudScaleX.Value;
 
             ValidateInstance(sender, e);
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            if (DialogResult != DialogResult.OK)
+            {
+                DialogResult = DialogResult.Cancel;
+                RestoreData();
+            }
+
+            base.OnFormClosing(e);
         }
 
         private void butCancel_Click(object sender, EventArgs e)

--- a/TombEditor/Forms/FormTransform.cs
+++ b/TombEditor/Forms/FormTransform.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Numerics;
 using System.Windows.Forms;
 using DarkUI.Forms;
@@ -18,6 +19,7 @@ namespace TombEditor.Forms
 
         private bool _loading = false;
         private bool _undoSaved = false;
+        private bool _lightingUpdatePending = false;
 
         public FormTransform(PositionBasedObjectInstance instance)
         {
@@ -39,6 +41,7 @@ namespace TombEditor.Forms
 
             _backupPosition = _instance.Position;
             _backupScale = _instance is IScaleable scaleable ? new Vector3(scaleable.Scale) : Vector3.One;
+
             _backupRotation = new Vector3(
                 _instance is IRotateableYX rotateableYX ? rotateableYX.RotationX : 0.0f,
                 _instance is IRotateableY rotateableY ? rotateableY.RotationY : 0.0f,
@@ -50,6 +53,8 @@ namespace TombEditor.Forms
             if (_instance == null)
                 return;
 
+            bool changed = HasTransformChangedFromBackup();
+
             _instance.Position = _backupPosition;
 
             if (_instance is IScaleable scaleable)
@@ -60,6 +65,25 @@ namespace TombEditor.Forms
                 rotateableYX.RotationX = _backupRotation.X;
             if (_instance is IRotateableYXRoll rotateableYXRoll)
                 rotateableYXRoll.Roll = _backupRotation.Z;
+
+            if (changed && _editor.ShouldRelight)
+                EditorActions.RebuildLightsForObject(_instance);
+        }
+
+        private bool HasPendingChanges()
+        {
+            if (_instance == null)
+                return false;
+
+            var position = new Vector3((float)nudTransX.Value - _instance.Room.Position.X * (int)Level.SectorSizeUnit,
+                                       (float)-nudTransY.Value - _instance.Room.Position.Y,
+                                       (float)nudTransZ.Value - _instance.Room.Position.Z * (int)Level.SectorSizeUnit);
+
+            return _instance.Position != position ||
+                   _instance is IScaleable scaleable && scaleable.Scale != (float)nudScaleX.Value ||
+                   _instance is IRotateableY rotateableY && rotateableY.RotationY != (float)nudRotY.Value ||
+                   _instance is IRotateableYX rotateableYX && rotateableYX.RotationX != (float)nudRotX.Value ||
+                   _instance is IRotateableYXRoll rotateableYXRoll && rotateableYXRoll.Roll != (float)nudRotZ.Value;
         }
 
         private void SaveData()
@@ -71,17 +95,52 @@ namespace TombEditor.Forms
                                              (float)-nudTransY.Value - _instance.Room.Position.Y,
                                              (float)nudTransZ.Value - _instance.Room.Position.Z * (int)Level.SectorSizeUnit);
 
-            if (_instance is IRotateableY rotateableY)
-                rotateableY.RotationY = (float)nudRotY.Value;
+            if (_instance is IRotateableY currentRotateableY)
+                currentRotateableY.RotationY = (float)nudRotY.Value;
 
-            if (_instance is IRotateableYX rotateableYX)
-                rotateableYX.RotationX = (float)nudRotX.Value;
+            if (_instance is IRotateableYX currentRotateableYX)
+                currentRotateableYX.RotationX = (float)nudRotX.Value;
 
-            if (_instance is IRotateableYXRoll rotateableYXRoll)
-                rotateableYXRoll.Roll = (float)nudRotZ.Value;
+            if (_instance is IRotateableYXRoll currentRotateableYXRoll)
+                currentRotateableYXRoll.Roll = (float)nudRotZ.Value;
 
-            if (_instance is IScaleable scaleable)
-                scaleable.Scale = (float)nudScaleX.Value;
+            if (_instance is IScaleable currentScaleable)
+                currentScaleable.Scale = (float)nudScaleX.Value;
+        }
+
+        private bool HasTransformChangedFromBackup()
+        {
+            return _instance.Position != _backupPosition ||
+                   _instance is IScaleable scaleable && scaleable.Scale != _backupScale.X ||
+                   _instance is IRotateableY rotateableY && rotateableY.RotationY != _backupRotation.Y ||
+                   _instance is IRotateableYX rotateableYX && rotateableYX.RotationX != _backupRotation.X ||
+                   _instance is IRotateableYXRoll rotateableYXRoll && rotateableYXRoll.Roll != _backupRotation.Z;
+        }
+
+        private void ApplyData()
+        {
+            if (!HasPendingChanges())
+                return;
+
+            if (!_undoSaved)
+            {
+                _editor.UndoManager.PushObjectTransformed(_instance);
+                _undoSaved = true;
+            }
+
+            SaveData();
+
+            if (_editor.ShouldRelight)
+            {
+                EditorActions.RebuildLightsForObject(_instance);
+                _lightingUpdatePending = false;
+            }
+            else if (EditorActions.GetLightingRoomsForObject(_instance).Any())
+            {
+                _lightingUpdatePending = true;
+            }
+
+            _editor.ObjectChange(_instance, ObjectChangeType.Change);
         }
 
         private void UpdateUI()
@@ -138,14 +197,7 @@ namespace TombEditor.Forms
             if (_loading)
                 return;
 
-            if (!_undoSaved)
-            {
-                _editor.UndoManager.PushObjectTransformed(_instance);
-                _undoSaved = true;
-            }
-
-            SaveData();
-            _editor.ObjectChange(_instance, ObjectChangeType.Change);
+            ApplyData();
         }
 
         private void nudScaleX_Validated(object sender, EventArgs e)
@@ -160,6 +212,7 @@ namespace TombEditor.Forms
         private void butCancel_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.Cancel;
+
             RestoreData();
             Close();
         }
@@ -167,7 +220,20 @@ namespace TombEditor.Forms
         private void butOk_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.OK;
-            SaveData();
+            bool changed = HasTransformChangedFromBackup();
+
+            ApplyData();
+
+            if (!changed)
+            {
+                _lightingUpdatePending = false;
+            }
+            else if (_lightingUpdatePending)
+            {
+                EditorActions.RebuildLightsForObject(_instance);
+                _lightingUpdatePending = false;
+            }
+
             Close();
         }
     }

--- a/TombEditor/ToolWindows/Lighting.cs
+++ b/TombEditor/ToolWindows/Lighting.cs
@@ -170,19 +170,19 @@ namespace TombEditor.ToolWindows
         private void cbLightIsDynamicallyUsed_CheckedChanged(object sender, EventArgs e)
         {
             EditorActions.UpdateLight<bool>((light, value) => light.IsDynamicallyUsed == value, (light, value) => light.IsDynamicallyUsed = value,
-                light => cbLightIsDynamicallyUsed.Checked);
+                light => cbLightIsDynamicallyUsed.Checked, updateLighting: false);
         }
 
         private void cbLightIsUsedForImportedGeometry_CheckedChanged(object sender, EventArgs e)
         {
             EditorActions.UpdateLight<bool>((light, value) => light.IsUsedForImportedGeometry == value, (light, value) => light.IsUsedForImportedGeometry = value,
-                light => cbLightIsUsedForImportedGeometry.Checked);
+                light => cbLightIsUsedForImportedGeometry.Checked, updateLighting: false);
         }
 
         private void cbLightCastsShadow_CheckedChanged(object sender, EventArgs e)
         {
             EditorActions.UpdateLight<bool>((light, value) => light.CastDynamicShadows == value, (light, value) => light.CastDynamicShadows = value,
-                light => cbLightCastsShadow.Checked);
+                light => cbLightCastsShadow.Checked, updateLighting: false);
         }
 
         private static bool Compare(float firstValue, float secondValue, NumericUpDown control)

--- a/TombEditor/Undo.cs
+++ b/TombEditor/Undo.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Threading;
 using System.Threading.Tasks;
 using TombLib;
 using TombLib.LevelData;
@@ -17,6 +17,34 @@ namespace TombEditor
 
         public Room Room { get; internal set; }
         protected EditorUndoRedoInstance(EditorUndoManager parent, Room room) { Parent = parent; Room = room; }
+    }
+
+    public class EditorUndoRedoBatch : EditorUndoRedoInstance
+    {
+        private readonly List<EditorUndoRedoInstance> _instances;
+
+        public EditorUndoRedoBatch(EditorUndoManager parent, IEnumerable<EditorUndoRedoInstance> instances) : base(parent, null)
+        {
+            _instances = [.. instances];
+
+            Valid = () => _instances.All(instance => instance.Valid == null || instance.Valid());
+            UndoAction = () => Execute(() => _instances.ForEach(instance => instance.UndoAction?.Invoke()));
+            RedoInstance = () => new EditorUndoRedoBatch(Parent, _instances.Select(instance => (EditorUndoRedoInstance)instance.RedoInstance()));
+        }
+
+        private void Execute(Action action)
+        {
+            Parent.BeginLightingBatch();
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Parent.EndLightingBatch();
+            }
+        }
     }
 
     public class AddSectorBasedObjectUndoInstance : EditorUndoRedoInstance
@@ -122,8 +150,10 @@ namespace TombEditor
                 else
                 {
                     var backupPos = obj.Position; // Preserve original position and reassign it after placement
-                    EditorActions.PlaceObjectWithoutUpdate(Room, obj.SectorPosition, UndoObject);
-                    EditorActions.MoveObject(UndoObject, backupPos);
+                    EditorActions.PlaceObjectWithoutUpdate(Room, obj.SectorPosition, UndoObject, updateLighting: false);
+                    UndoObject.Position = backupPos;
+                    EditorActions.RebuildLightsForObject(UndoObject);
+                    Parent.Editor.ObjectChange(UndoObject, ObjectChangeType.Change);
                 }
             };
 
@@ -165,10 +195,11 @@ namespace TombEditor
             UndoAction = () =>
             {
                 bool roomChanged = false;
+                Room oldRoom = null;
 
                 if (UndoObject.Room != Room)
                 {
-                    var oldRoom = UndoObject.Room;
+                    oldRoom = UndoObject.Room;
                     oldRoom.RemoveObject(Parent.Editor.Level, UndoObject);
                     Parent.Editor.ObjectChange(UndoObject, ObjectChangeType.Remove, oldRoom);
 
@@ -188,10 +219,10 @@ namespace TombEditor
                 // Rebuild lighting!
                 if (UndoObject is LightInstance)
                 {
-                    if (Parent.Editor.ShouldRelight)
-                        Room.RebuildLighting(Parent.Editor.Configuration.Rendering3D_HighQualityLightPreview);
+                    if (roomChanged)
+                        Parent.UpdateRoomsLighting([oldRoom, Room]);
                     else
-                        Room.PendingRelight = true;
+                        Parent.UpdateRoomLighting(Room);
                 }
 
                 // Move origin of object group, if it contains object
@@ -304,7 +335,7 @@ namespace TombEditor
                 else if (UndoObject is LightInstance)
                 {
                     ((LightInstance)UndoObject).Color = (Vector3)Properties[0];
-                    UndoObject.Room.RebuildLighting(parent.Editor.Configuration.Rendering3D_HighQualityLightPreview);
+                    parent.UpdateRoomLighting(UndoObject.Room);
                 }
                 else if (UndoObject is SinkInstance)
                     ((SinkInstance)UndoObject).Strength = (short)Properties[0];
@@ -391,7 +422,7 @@ namespace TombEditor
                 bool rebuildLighting = Room.Properties.AmbientLight != Properties.AmbientLight;
                 Room.Properties = Properties;
                 if (rebuildLighting)
-                    Room.RebuildLighting(parent.Editor.Configuration.Rendering3D_HighQualityLightPreview);
+                    parent.Editor.UpdateRoomLighting(Room);
                 Parent.Editor.RoomPropertiesChange(Room);
             };
             RedoInstance = () => new RoomPropertyUndoInstance(Parent, Room);
@@ -443,6 +474,7 @@ namespace TombEditor
     public class EditorUndoManager : UndoManager
     {
         public Editor Editor;
+        private HashSet<Room> _lightingBatchRooms;
 
         public EditorUndoManager(Editor editor, int undoDepth) : base(undoDepth)
         {
@@ -450,6 +482,46 @@ namespace TombEditor
 
             UndoStackChanged += (s, e) => Editor.UndoStackChanged();
             MessageSent += (s, e) => Editor.SendMessage(e.Message, TombLib.Forms.PopupType.Warning);
+        }
+
+        internal void BeginLightingBatch()
+        {
+            _lightingBatchRooms = [];
+        }
+
+        internal void EndLightingBatch()
+        {
+            var rooms = _lightingBatchRooms;
+            _lightingBatchRooms = null;
+
+            Editor.UpdateRoomsLighting(rooms);
+        }
+
+        internal void UpdateRoomLighting(Room room)
+        {
+            if (_lightingBatchRooms is not null)
+            {
+                _lightingBatchRooms.Add(room);
+                return;
+            }
+
+            Editor.UpdateRoomLighting(room);
+        }
+
+        internal void UpdateRoomsLighting(IEnumerable<Room> rooms)
+        {
+            if (_lightingBatchRooms is not null)
+            {
+                foreach (var room in rooms)
+                {
+                    if (room is not null)
+                        _lightingBatchRooms.Add(room);
+                }
+
+                return;
+            }
+
+            Editor.UpdateRoomsLighting(rooms);
         }
 
         public void PushRoomCreated(Room room) => Push(new AddRoomUndoInstance(this, room));
@@ -470,7 +542,7 @@ namespace TombEditor
         public void PushObjectPropertyChanged(PositionBasedObjectInstance obj)
         {
             if (obj is ObjectGroup)
-                Push(((ObjectGroup)obj).Select(o => new ChangeObjectPropertyUndoInstance(this, o)).Cast<UndoRedoInstance>().ToList());
+                Push(new EditorUndoRedoBatch(this, ((ObjectGroup)obj).Select(o => new ChangeObjectPropertyUndoInstance(this, o))));
             else
                 Push(new ChangeObjectPropertyUndoInstance(this, obj));
         }
@@ -478,7 +550,7 @@ namespace TombEditor
         public void PushObjectTransformed(PositionBasedObjectInstance obj)
         {
             if (obj is ObjectGroup)
-                Push(((ObjectGroup)obj).Select(o => new TransformObjectUndoInstance(this, o)).Cast<UndoRedoInstance>().ToList());
+                Push(new EditorUndoRedoBatch(this, ((ObjectGroup)obj).Select(o => new TransformObjectUndoInstance(this, o))));
             else
                 Push(new TransformObjectUndoInstance(this, obj));
         }

--- a/TombLib/TombLib.Test/RoomLightingInvalidationTests.cs
+++ b/TombLib/TombLib.Test/RoomLightingInvalidationTests.cs
@@ -1,0 +1,120 @@
+using System.Numerics;
+using System.Reflection;
+using TombLib.LevelData;
+
+namespace TombLib.Test;
+
+[TestClass]
+public class RoomLightingInvalidationTests
+{
+    [TestMethod]
+    public void AddLightInvalidatesLighting()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+
+        Assert.IsFalse(room.PendingRelight);
+
+        room.AddObject(level, new LightInstance(LightType.Point));
+
+        Assert.IsTrue(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void AddNonLightDoesNotInvalidateLighting()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+
+        room.AddObject(level, new CameraInstance());
+
+        Assert.IsFalse(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void RemoveLightInvalidatesLighting()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+        var light = new LightInstance(LightType.Point);
+
+        room.AddObject(level, light);
+        room.RebuildLighting(highQualityLighting: false);
+        room.RemoveObject(level, light);
+
+        Assert.IsTrue(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void RemoveNonLightDoesNotInvalidateLighting()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+        var camera = new CameraInstance();
+
+        room.AddObject(level, camera);
+        room.RebuildLighting(highQualityLighting: false);
+        room.RemoveObject(level, camera);
+
+        Assert.IsFalse(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void MoveLightInvalidatesBothRooms()
+    {
+        var level = Level.CreateSimpleLevel();
+        var sourceRoom = level.Rooms[0];
+        var destinationRoom = new Room(level, Room.DefaultRoomDimensions, Room.DefaultRoomDimensions, Vector3.Zero, "Room 1");
+        var light = new LightInstance(LightType.Point);
+
+        sourceRoom.AddObject(level, light);
+        sourceRoom.RebuildLighting(highQualityLighting: false);
+
+        destinationRoom.MoveObjectFrom(level, sourceRoom, light);
+
+        Assert.IsTrue(sourceRoom.PendingRelight);
+        Assert.IsTrue(destinationRoom.PendingRelight);
+    }
+
+    [TestMethod]
+    public void BuildGeometryInvalidatesLighting()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+
+        room.RebuildLighting(highQualityLighting: false);
+        room.BuildGeometry();
+
+        Assert.IsTrue(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void RebuildLightingClearsPendingState()
+    {
+        var level = Level.CreateSimpleLevel();
+        var room = level.Rooms[0];
+
+        room.InvalidateLighting();
+        room.RebuildLighting(highQualityLighting: false);
+
+        Assert.IsFalse(room.PendingRelight);
+    }
+
+    [TestMethod]
+    public void OverrideIndividualLightQualityUsesDefaultQuality()
+    {
+        var light = new LightInstance(LightType.Point)
+        {
+            Quality = LightQuality.High
+        };
+
+        var getLightSampleCount = typeof(RoomGeometry).GetMethod("GetLightSampleCount", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(getLightSampleCount);
+
+        var explicitQualitySampleCount = (int)getLightSampleCount!.Invoke(null, [light, LightQuality.Low, false])!;
+        var overriddenQualitySampleCount = (int)getLightSampleCount.Invoke(null, [light, LightQuality.Low, true])!;
+
+        Assert.AreEqual(5, explicitQualitySampleCount);
+        Assert.AreEqual(1, overriddenQualitySampleCount);
+    }
+}

--- a/TombLib/TombLib/LevelData/Room.cs
+++ b/TombLib/TombLib/LevelData/Room.cs
@@ -136,7 +136,7 @@ namespace TombLib.LevelData
 
         // Internal data structures
         public RoomGeometry RoomGeometry { get; } = new RoomGeometry();
-        public bool PendingRelight { get; set; } = true;
+        public bool PendingRelight { get; private set; } = true;
 
         private IEnumerable<PortalInstance> _portalsCache;
 
@@ -955,27 +955,27 @@ namespace TombLib.LevelData
         public void Rebuild(bool relight, bool highQualityLighting = false)
         {
             RoomGeometry.Build(this);
+            InvalidateLighting();
 
             if (relight)
-            {
-                RoomGeometry.Relight(this, highQualityLighting);
-                PendingRelight = false;
-            }
-            else
-            {
-                PendingRelight = true;
-            }
+                RebuildLighting(highQualityLighting);
         }
 
         public void BuildGeometry(bool useLegacyCode = false)
         {
             RoomGeometry.Build(this, useLegacyCode);
+            InvalidateLighting();
         }
 
         public void RebuildLighting(bool highQualityLighting)
         {
             RoomGeometry.Relight(this, highQualityLighting);
             PendingRelight = false;
+        }
+
+        public void InvalidateLighting()
+        {
+            PendingRelight = true;
         }
 
         public Matrix4x4 Transform => Matrix4x4.CreateTranslation(WorldPos);
@@ -1212,6 +1212,9 @@ namespace TombLib.LevelData
                 throw;
             }
 
+            if (instance is LightInstance)
+                InvalidateLighting();
+
             return instance;
         }
 
@@ -1228,6 +1231,9 @@ namespace TombLib.LevelData
                 if (!CoordinateInvalid(ghost.SectorPosition))
                     Sectors[ghost.SectorPosition.X, ghost.SectorPosition.Y].GhostBlock = null;
             }
+
+            if (instance is LightInstance)
+                InvalidateLighting();
 
             return instance;
         }

--- a/TombLib/TombLib/LevelData/RoomGeometry.cs
+++ b/TombLib/TombLib/LevelData/RoomGeometry.cs
@@ -1091,9 +1091,11 @@ namespace TombLib.LevelData
             RayTraceZ(room, (int)position.X, (int)position.Y, (int)position.Z, (int)lightPosition.X, (int)lightPosition.Y, (int)lightPosition.Z));
         }
 
-        private static int GetLightSampleCount(LightInstance light, LightQuality defaultQuality = LightQuality.Low)
+        private static int GetLightSampleCount(LightInstance light, LightQuality defaultQuality, bool overrideIndividualQualitySettings)
         {
-            LightQuality quality = light.Quality == LightQuality.Default ? defaultQuality : light.Quality;
+            LightQuality quality = overrideIndividualQualitySettings || light.Quality == LightQuality.Default
+                ? defaultQuality
+                : light.Quality;
 
             return quality switch
             {
@@ -1144,7 +1146,7 @@ namespace TombLib.LevelData
                 return 1.0f;
 
             int numSamples = highQuality
-                ? GetLightSampleCount(light, room.Level.Settings.DefaultLightQuality)
+                ? GetLightSampleCount(light, room.Level.Settings.DefaultLightQuality, room.Level.Settings.OverrideIndividualLightQualitySettings)
                 : 1;
 
             float result = GetSampleSumFromLightTracing(numSamples, room, position, light);


### PR DESCRIPTION
Need to test:
- [ ] Generic and palette light colors, including grouped lights across multiple rooms.
- [ ] Color-dialog Cancel restoration.
- [ ] Cross-room moves in and out of Lighting mode, including undo/redo.
- [ ] Point, spot, and sun rotation resets.
- [ ] Transform-dialog position, rotation, scale, OK, and Cancel.
- [ ] Light deletion and undo-delete.
- [ ] Ambient lighting and undo/redo.
- [ ] Preview-quality toggling, default quality, and override quality.
- [ ] Dirty-state behavior, deferred mode-entry relighting, cache refresh, and large-level relight timing.