### PR TITLE
Tomb Editor: Set automatic key trigger while a slot is selected

### DIFF
--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -1,4 +1,4 @@
-﻿using DarkUI.Forms;
+using DarkUI.Forms;
 using NLog;
 using System;
 using System.Collections.Concurrent;
@@ -679,8 +679,11 @@ namespace TombEditor
                 objectList = objectList.OrderByDescending(o =>
                 {
                     var objectName = string.Empty;
-					if (o is MoveableInstance)
-						objectName = (o as MoveableInstance).WadObjectId.ShortName(_editor.Level.Settings.GameVersion).ToLower();
+                    if (o is MoveableInstance mov)
+                    {
+                        var tenSlot = TrCatalog.GetMoveableTombEngineSlot(_editor.Level.Settings.GameVersion, mov.WadObjectId.TypeId);
+                        objectName = (!string.IsNullOrEmpty(tenSlot) ? tenSlot : mov.WadObjectId.ShortName(_editor.Level.Settings.GameVersion)).ToLower();
+                    }
 
                     bool isSwitch = objectName.Contains("switch") || objectName.Contains("pulley");
                     bool isHole = objectName.Contains("hole") &&


### PR DESCRIPTION
This PR is meant for automatically set Key Trigger when you have a slot or a lock selected.
This already work with TEN, but with other TRs not
I tested with TR1X
This also resolves my previous feature request #1214