### PR TITLE
Add warning if multiple LARA objects are placed in a level.

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -19,6 +19,7 @@ Tomb Editor:
  * Added support for flyby cameras in TRX.
  * Added support for specifying moveable instance names in TRX.
  * Added support for moveable item properties in TRX levels; refer to LostArtefacts documentation.
+ * Added warning if multiple LARA objects are placed in the level.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -19,7 +19,7 @@ Tomb Editor:
  * Added support for flyby cameras in TRX.
  * Added support for specifying moveable instance names in TRX.
  * Added support for moveable item properties in TRX levels; refer to LostArtefacts documentation.
- * Added warning if multiple LARA objects are placed in the level.
+ * Added an error that prevents level compilation if multiple Lara objects are placed in the level.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -19,7 +19,7 @@ Tomb Editor:
  * Added support for flyby cameras in TRX.
  * Added support for specifying moveable instance names in TRX.
  * Added support for moveable item properties in TRX levels; refer to LostArtefacts documentation.
- * Added an error that prevents level compilation if multiple Lara objects are placed in the level.
+ * Added level compilation warning for TombEngine targets if multiple Lara objects are placed in the level.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -4244,14 +4244,6 @@ namespace TombEditor
         {
             Level level = _editor.Level;
 
-            if (LaraObjectCount() > 1)
-            {
-                if (!silent)
-                    _editor.SendMessage("Multiple Lara objects detected.\n" +
-                                        "Remove the extra Lara objects before compiling.", PopupType.Error);
-                return false;
-            }
-
             if (!level.Settings.Wads.All(wad => wad.Wad != null))
             {
                 if (!silent)
@@ -4443,12 +4435,6 @@ namespace TombEditor
             return _editor?.Level?.Settings?.WadTryGetMoveable(WadMoveableId.Lara) != null &&
                    _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
                                               .Any(IsLaraObject);
-        }
-
-        private static int LaraObjectCount()
-        {
-            return _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
-                                              .Count(IsLaraObject);
         }
 
         private static bool IsLaraObject(ObjectInstance obj)

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -4441,13 +4441,19 @@ namespace TombEditor
         public static bool IsLaraInLevel()
         {
             return _editor?.Level?.Settings?.WadTryGetMoveable(WadMoveableId.Lara) != null &&
-                   LaraObjectCount() > 0;
+                   _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
+                                              .Any(IsLaraObject);
         }
 
         private static int LaraObjectCount()
         {
             return _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
-                    .Count(obj => obj is ItemInstance item && item.ItemType == new ItemType(WadMoveableId.Lara));
+                                              .Count(IsLaraObject);
+        }
+
+        private static bool IsLaraObject(ObjectInstance obj)
+        {
+            return obj is ItemInstance && ((ItemInstance)obj).ItemType == new ItemType(WadMoveableId.Lara);
         }
 
         public static bool AddAndPlaceImportedGeometry(IWin32Window owner, VectorInt2 position, string file)

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -4244,6 +4244,14 @@ namespace TombEditor
         {
             Level level = _editor.Level;
 
+            if (LaraObjectCount() > 1)
+            {
+                if (!silent)
+                    _editor.SendMessage("Multiple Lara objects detected.\n" +
+                                        "Remove the extra Lara objects before compiling.", PopupType.Error);
+                return false;
+            }
+
             if (!level.Settings.Wads.All(wad => wad.Wad != null))
             {
                 if (!silent)
@@ -4433,8 +4441,13 @@ namespace TombEditor
         public static bool IsLaraInLevel()
         {
             return _editor?.Level?.Settings?.WadTryGetMoveable(WadMoveableId.Lara) != null &&
-                   _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
-                                              .Any(obj => obj is ItemInstance && ((ItemInstance)obj).ItemType == new ItemType(WadMoveableId.Lara));
+                   LaraObjectCount() > 0;
+        }
+
+        private static int LaraObjectCount()
+        {
+            return _editor.Level.ExistingRooms.SelectMany(room => room.Objects)
+                    .Count(obj => obj is ItemInstance item && item.ItemType == new ItemType(WadMoveableId.Lara));
         }
 
         public static bool AddAndPlaceImportedGeometry(IWin32Window owner, VectorInt2 position, string file)

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -445,6 +445,8 @@ namespace TombLib.LevelData.Compilers.TombEngine
             _moveablesTable = new Dictionary<MoveableInstance, int>(new ReferenceEqualityComparer<MoveableInstance>());
             _aiObjectsTable = new Dictionary<MoveableInstance, int>(new ReferenceEqualityComparer<MoveableInstance>());
 
+            bool laraPlaced = false;
+
             foreach (Room room in _level.ExistingRooms)
                 foreach (var instance in room.Objects.OfType<MoveableInstance>())
                 {
@@ -453,6 +455,17 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     {
                         _progressReporter.ReportWarn("Moveable '" + instance + "' was not included in the level because it is missing the *.wad file.");
                         continue;
+                    }
+
+                    if (wadMoveable.Id.TypeId == 0)
+                    {
+                        if (laraPlaced)
+                        {
+                            _progressReporter.ReportWarn("Extra Lara was found and removed from room " + instance.Room + " to prevent crashes. Please use only one Lara in level.");
+                            continue;
+                        }
+                        else
+                            laraPlaced = true;
                     }
 
                     Vector3 position = instance.Room.WorldPos + instance.Position;


### PR DESCRIPTION
This pull request introduces a validation and error-handling mechanism to ensure only one Lara object is present in a level for **TombEngine targets** . This brings the level compiler in-line with other targets

**Level validation and error handling:**

* Added a check in the Tomb Editor to prevent level compilation if multiple Lara objects are placed, with an error message guiding the user to use only one Lara per level.
* In `LevelCompilerTombEngine.cs`, implemented logic to detect multiple Lara instances during item preparation. If more than one is found, extra instances are removed and a warning is reported to the user. [[1]](diffhunk://#diff-8ba33788c5b1ab0702af3bf2eaadf71485872af27753d7b5d8d06fc374668e92R448-R449) [[2]](diffhunk://#diff-8ba33788c5b1ab0702af3bf2eaadf71485872af27753d7b5d8d06fc374668e92R460-R470)

**Code refactoring:**

* In `EditorActions.cs`, extracted the Lara object check into a new helper method `IsLaraObject` for improved readability and maintainability.

Prevents #1287 