### PR TITLE
Fix TR1 and TR2 pistol ammo

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -23,6 +23,7 @@ Tomb Editor:
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.
  * Fixed being unable to use sound IDs in TRX levels above the OG sound map size without defining all lower IDs
+ * Fixed pistol ammo pickups in TR1 and TR2 not being converted to the correct engine type.
 
 WadTool:
  * Added an option to consolidate textures for an object into a single set of texture pages.

--- a/TombLib/TombLib/Catalogs/Engines/TR1/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR1/Moveables.xml
@@ -90,7 +90,7 @@
     <moveable id="100" name="Shotgun" id2="85" ten="SHOTGUN_ITEM" />
     <moveable id="101" name="Magnum" id2="86" />
     <moveable id="102" name="Uzi" id2="87" ten="UZI_ITEM" />
-    <moveable id="103" name="Pistol ammo" ten="PISTOLS_AMMO_ITEM" />
+    <moveable id="103" name="Pistol ammo" id2="88" ten="PISTOLS_AMMO_ITEM" />
     <moveable id="104" name="Shotgun ammo" id2="89" ten="SHOTGUN_AMMO1_ITEM" />
     <moveable id="105" name="Magnum ammo" id2="90" />
     <moveable id="106" name="Uzi ammo" id2="91" ten="UZI_AMMO_ITEM" />

--- a/TombLib/TombLib/Catalogs/Engines/TR1/SpriteSequences.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR1/SpriteSequences.xml
@@ -4,7 +4,7 @@
     <sprite_sequence id="85" name="Shotgun" />
     <sprite_sequence id="86" name="Magnums" />
     <sprite_sequence id="87" name="Uzis" />
-    <sprite_sequence id="88" name="Pistol ammo(?)" />
+    <sprite_sequence id="88" name="Pistol ammo" />
     <sprite_sequence id="89" name="Shotgun ammo" />
     <sprite_sequence id="90" name="Magnum ammo" />
     <sprite_sequence id="91" name="Uzi ammo" />

--- a/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
@@ -140,7 +140,7 @@
     <moveable id="161" name="Harpoon gun" id2="139" ten="HARPOON_ITEM"/>
     <moveable id="162" name="M16" id2="140" ten="HK_ITEM"/>
     <moveable id="163" name="Grenade launcher" id2="141" ten="GRENADE_GUN_ITEM"/>
-    <moveable id="164" name="Pistol ammo"  ten="PISTOL_AMMO_ITEM"/>
+    <moveable id="164" name="Pistol ammo" id2="142" ten="PISTOL_AMMO_ITEM"/>
     <moveable id="165" name="Shotgun ammo" id2="143" ten="SHOTGUN_AMMO1_ITEM"/>
     <moveable id="166" name="Auto-pistol ammo" id2="144" ten="PISTOLS_AMMO_ITEM"/>
     <moveable id="167" name="Uzi ammo" id2="145" ten="UZI_AMMO_ITEM"/>

--- a/TombLib/TombLib/Catalogs/Engines/TR2/SpriteSequences.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/SpriteSequences.xml
@@ -10,6 +10,7 @@
     <sprite_sequence id="139" name="Harpoon gun" />
     <sprite_sequence id="140" name="M16" />
     <sprite_sequence id="141" name="Grenade launcher" />
+    <sprite_sequence id="142" name="Pistol ammo" />
     <sprite_sequence id="143" name="Shotgun shells" />
     <sprite_sequence id="144" name="Auto-pistol clips" />
     <sprite_sequence id="145" name="Uzi clips" />


### PR DESCRIPTION
This fixes pistol ammo in TR1 and TR2 not being converted to the expected engine type when compiling.